### PR TITLE
Replace moment with luxon

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,8 +27,8 @@
         "chart.js": "^2.9.4",
         "copyfiles": "^2.4.1",
         "leaflet": "1",
+        "luxon": "^3.4.0",
         "maplibre-gl": "^2.4.0",
-        "moment": "^2.29.4",
         "rxjs": "~7.5.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.11.4"
@@ -40,6 +40,7 @@
         "@types/geojson": "^7946.0.10",
         "@types/jasmine": "~3.10.0",
         "@types/leaflet": "^1.9.3",
+        "@types/luxon": "^3.3.1",
         "@types/node": "^18.0.0",
         "jasmine-core": "~4.0.0",
         "karma": "~6.3.0",
@@ -4546,6 +4547,12 @@
         "@types/leaflet": "*"
       }
     },
+    "node_modules/@types/luxon": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.3.1.tgz",
+      "integrity": "sha512-XOS5nBcgEeP2PpcqJHjCWhUCAzGfXIU8ILOSLpx2FhxqMW9KdxgCGXNOEKGVBfveKtIpztHzKK5vSRVLyW/NqA==",
+      "dev": true
+    },
     "node_modules/@types/mapbox__point-geometry": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/@types/mapbox__point-geometry/-/mapbox__point-geometry-0.1.2.tgz",
@@ -4568,9 +4575,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.17.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.3.tgz",
-      "integrity": "sha512-2x8HWtFk0S99zqVQABU9wTpr8wPoaDHZUcAkoTKH+nL7kPv3WUI9cRi/Kk5Mz4xdqXSqTkKP7IWNoQQYCnDsTA==",
+      "version": "18.17.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.4.tgz",
+      "integrity": "sha512-ATL4WLgr7/W40+Sp1WnNTSKbgVn6Pvhc/2RHAdt8fl6NsQyp4oPCi2eKcGOvA494bwf1K/W6nGgZ9TwDqvpjdw==",
       "dev": true
     },
     "node_modules/@types/parse-json": {
@@ -9152,6 +9159,14 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/luxon": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.0.tgz",
+      "integrity": "sha512-7eDo4Pt7aGhoCheGFIuq4Xa2fJm4ZpmldpGhjTYBNUYNCN6TIEP6v7chwwwt3KRp7YR+rghbfvjyo3V5y9hgBw==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.29.0",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.29.0.tgz",
@@ -11409,9 +11424,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "3.27.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.27.2.tgz",
-      "integrity": "sha512-YGwmHf7h2oUHkVBT248x0yt6vZkYQ3/rvE5iQuVBh3WO8GcJ6BNeOkpoX1yMHIiBm18EMLjBPIoUDkhgnyxGOQ==",
+      "version": "3.28.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.28.0.tgz",
+      "integrity": "sha512-d7zhvo1OUY2SXSM6pfNjgD5+d0Nz87CUp4mt8l/GgVP3oBsPwzNvSzyu1me6BSG9JIgWNTVcafIXBIyM8yQ3yw==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
     "chart.js": "^2.9.4",
     "copyfiles": "^2.4.1",
     "leaflet": "1",
+    "luxon": "^3.4.0",
     "maplibre-gl": "^2.4.0",
-    "moment": "^2.29.4",
     "rxjs": "~7.5.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.11.4"
@@ -41,6 +41,7 @@
     "@types/geojson": "^7946.0.10",
     "@types/jasmine": "~3.10.0",
     "@types/leaflet": "^1.9.3",
+    "@types/luxon": "^3.3.1",
     "@types/node": "^18.0.0",
     "jasmine-core": "~4.0.0",
     "karma": "~6.3.0",

--- a/src/app/models/airgradient/agChartPeriods.ts
+++ b/src/app/models/airgradient/agChartPeriods.ts
@@ -1,27 +1,15 @@
+import {DateTime, Duration} from "luxon";
+
 export class AgChartPeriods {
-  name: string;
-  bucket: string;
-  since: string;
-  chartunit:any;
-  trial_plan_locked: boolean;
-  home_plan_locked: boolean;
-  maxSpanMinutes: number;
-  oAqBucket: string;
-  momentBucket: any;
-  momentBucketDeduct: number;
-
-  constructor(name:string, bucket: string, since: string, chartunit:string, trial_plan_locked:boolean=false, home_plan_locked:boolean=false, maxSpanMinutes:number=100, openAQBucket: string, momentBucket: any, momentBucketDeduct: number) {
-    this.name=name;
-    this.bucket=bucket;
-    this.since=since;
-    this.chartunit=chartunit;
-    this.chartunit=chartunit;
-    this.trial_plan_locked=trial_plan_locked;
-    this.home_plan_locked=home_plan_locked;
-    this.maxSpanMinutes=maxSpanMinutes;
-	this.oAqBucket=openAQBucket;
-	this.momentBucket = momentBucket;
-	this.momentBucketDeduct = momentBucketDeduct;
-  }
-
+  constructor(
+    public readonly name: string,
+    public readonly bucket: string,
+    public readonly since: string,
+    public readonly chartunit:string,
+    public readonly trial_plan_locked:boolean=false,
+    public readonly home_plan_locked:boolean=false,
+    public readonly maxSpanMinutes: number = 100,
+    public readonly oAqBucket: string,
+    public readonly duration: Duration
+  ) { }
 }


### PR DESCRIPTION
Moment is still a dependency due to chart.js requiring it. There is no reduction in bundle size, though this improves the handling of dates regardless and I think still worthwhile. See #5 for further details on where we could go next with this.

Note that this will likely crate a merge conflict with #6 due to both changing package.json and package-lock.json. I'm happy to rebase either if required.